### PR TITLE
Improve connection error logging

### DIFF
--- a/backend/ble_worker.py
+++ b/backend/ble_worker.py
@@ -472,7 +472,11 @@ async def _connect_to_cube(device, real_mac: Optional[str]) -> Optional[GanCubeC
             return connection
             
         except Exception as e:
-            _log(f"❌ Connection attempt {attempt + 1} failed: {e}")
+            import traceback
+            error_details = traceback.format_exc().strip()
+            _log(
+                f"❌ Connection attempt {attempt + 1} failed: {type(e).__name__}: {e}\n{error_details}"
+            )
             if attempt < MAX_RECONNECT_ATTEMPTS - 1:
                 _log(f"⏳ Retrying in {RECONNECT_DELAY}s...")
                 await asyncio.sleep(RECONNECT_DELAY)


### PR DESCRIPTION
## Summary
- log detailed stack traces on connection failures

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881969d83e4832593d768e474e191d0