### PR TITLE
Fix solved state detection

### DIFF
--- a/backend/gan_decrypt.py
+++ b/backend/gan_decrypt.py
@@ -20,9 +20,9 @@ _DECODED_KEYS = [
 FACE_NAMES = ['U', 'R', 'F', 'D', 'L', 'B']
 MOVE_NAMES = ['U', 'R', 'F', 'D', 'L', 'B', "U'", "R'", "F'", "D'", "L'", "B'"]
 
-# Solved state constant - user's cube specific solved pattern
-# This cube has a non-standard color arrangement when solved
-SOLVED_STATE = "BUUBUULUUBBBRRRRRRURRUFFUFFRDDFDDFDDLLFLLFLLFLLDBBDBBD"
+# Solved state constant - standard color arrangement (URFDLB)
+# Used for detecting when the cube returns to the factory solved state
+SOLVED_STATE = "UUUUUUUUURRRRRRRRRFFFFFFFFFDDDDDDDDDLLLLLLLLLBBBBBBBBB"
 
 # Corner and edge facelet mappings (from JavaScript implementation)
 CORNER_FACELET_MAP = [


### PR DESCRIPTION
## Summary
- use a standard solved facelets string when checking cube status

## Testing
- `python -m compileall -q backend`
- `python test_pi_audio.py` *(fails: 'PiAudioManager' object has no attribute 'start_alarm_sound')*

------
https://chatgpt.com/codex/tasks/task_e_68819cd58bd083259a38f384c276ea5f