### PR TITLE
Add Pi setup details

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,110 @@
+# Cube Alarm
+
+This project turns a GAN Bluetooth cube into an alarm clock. When the alarm rings you must solve your cube to dismiss it!
+
+## Backend (Python)
+
+1. Install dependencies
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Run the server
+   ```bash
+   python backend/alarm_server.py
+   ```
+
+## Frontend (React)
+
+1. Install dependencies
+   ```bash
+   cd frontend
+   npm install
+   ```
+2. Start the dev server
+   ```bash
+   npm start
+   ```
+
+## Getting your cube MAC address
+
+The backend needs the real BLE MAC address of your cube. Run the BLE worker to scan and note the `Manufacturer MAC` it prints:
+```bash
+python backend/ble_worker.py
+```
+Set this address in a `.env` file or export `CUBE_MAC` before launching the server.
+
+## Raspberry Pi Setup
+
+### Flashing Raspberry Pi OS
+
+Use the [Raspberry Pi Imager](https://www.raspberrypi.com/software/) to write
+Raspberry Pi OS Lite to a microSD card. Boot the Pi, connect it to your network
+then clone this repo and run `setup_pi.sh`.
+
+### Bluetooth
+
+Enable the Bluetooth service and pair your cube if needed:
+
+```bash
+sudo systemctl enable bluetooth
+sudo systemctl start bluetooth
+```
+
+### Audio through the headphone jack
+
+Route audio to the 3.5mm jack:
+
+```bash
+sudo raspi-config
+```
+
+Choose **Advanced Options → Audio → Headphones**.
+
+### Setting volume
+
+You can raise the default volume with PulseAudio:
+
+```bash
+pactl set-sink-volume 0 80%
+```
+
+### Running the server as a service
+
+`setup_pi.sh` installs a systemd unit named `cube-alarm.service`.
+Enable it at boot and start (or restart) it when needed:
+
+```bash
+sudo systemctl enable cube-alarm.service
+sudo systemctl restart cube-alarm.service
+```
+
+Check logs with:
+
+```bash
+sudo journalctl -u cube-alarm -f
+```
+
+### Serving the React app with nginx
+
+After building the frontend you can serve it with nginx:
+
+```bash
+cd frontend
+npm install
+npm run build
+sudo cp -r build/* /var/www/html/
+sudo systemctl enable nginx
+sudo systemctl start nginx
+```
+
+## Hardware
+
+You can purchase the GAN cube used for this project here: [GAN Smart Cube](https://amzn.to/4lgux9D).
+
+## Credits
+
+Huge thanks to [afedotov/gan-web-bluetooth](https://github.com/afedotov/gan-web-bluetooth) for the original logic used to communicate with the cube.
+
+## License
+
+This project is released under the custom license found in `LICENSE.txt`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ flask-cors>=4.0.0
 schedule>=1.2.0
 lzstring>=1.0.4
 numpy>=1.24.0
+requests>=2.31.0
+pygame>=2.5.2


### PR DESCRIPTION
## Summary
- expand documentation with Bluetooth, audio, nginx and service setup
- mention cube MAC address in `.env`, link to cube on Amazon, and credit afedotov/gan-web-bluetooth
- include requests and pygame in requirements
- revert App.test.tsx and service start command in setup script

## Testing
- `pytest -q`
- `CI=true npm test --silent` *(fails: Unable to find learn react link)*

------
https://chatgpt.com/codex/tasks/task_e_6883b9c676348325969970068e73c4e1