### PR TITLE
Implement active alarms endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# Cube Alarm
+
+This repository contains the server and frontend code for the Rubik's Cube alarm clock.
+
+## API Endpoints
+
+The backend exposes a small set of HTTP routes for managing alarms and cube state.
+
+- `GET /api/alarms` – retrieve all alarms
+- `GET /api/alarms/active` – list alarms that are currently ringing
+- `POST /api/alarms` – create a new alarm
+- `PUT /api/alarms/<id>` – update an alarm
+- `DELETE /api/alarms/<id>` – delete an alarm
+- `POST /api/alarms/<id>/stop` – stop a specific alarm
+- `POST /api/alarms/stop` – stop all alarms

--- a/backend/alarm_server.py
+++ b/backend/alarm_server.py
@@ -103,6 +103,12 @@ class AlarmManager:
     def get_alarms(self) -> List[Dict]:
         """Get all alarms."""
         return [asdict(alarm) for alarm in self.alarms.values()]
+
+    def get_active_alarms(self) -> List[Dict]:
+        """Return a list of currently active alarms."""
+        return [asdict(self.alarms[alarm_id])
+                for alarm_id in self.active_alarms
+                if alarm_id in self.alarms]
     
     def trigger_alarm(self, alarm_id: str):
         """Trigger an alarm."""
@@ -305,6 +311,11 @@ alarm_manager = AlarmManager()
 def get_alarms():
     """Get all alarms."""
     return jsonify(alarm_manager.get_alarms())
+
+@app.route('/api/alarms/active', methods=['GET'])
+def get_active_alarms():
+    """Get all currently active alarms."""
+    return jsonify(alarm_manager.get_active_alarms())
 
 @app.route('/api/alarms', methods=['POST'])
 def create_alarm():


### PR DESCRIPTION
## Summary
- return list of active alarms from the alarm manager
- expose `GET /api/alarms/active` route
- document available API endpoints in README

## Testing
- `python -m py_compile backend/alarm_server.py backend/ble_worker.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887a53f86988325acd6b8fda567b338