### PR TITLE
Fix cube visualization move data

### DIFF
--- a/backend/alarm_server.py
+++ b/backend/alarm_server.py
@@ -192,6 +192,7 @@ class AlarmManager:
         
         # Emit cube move update
         socketio.emit('cube_move', {
+            'move': move.move,
             'face': move.face,
             'direction': move.direction,
             'timestamp': datetime.now().isoformat()

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -103,9 +103,9 @@ const App: React.FC = () => {
       setCubeState(prev => ({ ...prev, connected: data.connected }));
     });
 
-    socket.on('cube_move', (data: { face: string; direction: string }) => {
+    socket.on('cube_move', (data: { move: string; face: number; direction: number }) => {
       console.log('Cube move:', data);
-      const moveStr = `${data.face}${data.direction === 'prime' ? "'" : ''}`;
+      const moveStr = data.move || `${data.face}${data.direction ? "'" : ''}`;
       setLastMove(moveStr);
       // If we receive moves, cube must be connected
       // Don't automatically set solved=false - let solved events control this


### PR DESCRIPTION
## Summary
- send move string in cube_move events
- use move string in frontend socket handler

## Testing
- `npm test --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_688995873b188325adba5e8e9bcaad9b