### PR TITLE
Fix service path by using $HOME

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Set this address in a `.env` file or export `CUBE_MAC` before launching the serv
 Use the [Raspberry Pi Imager](https://www.raspberrypi.com/software/) to write
 Raspberry Pi OS Lite to a microSD card. Boot the Pi, connect it to your network
 then clone this repo and run `setup_pi.sh`.
+The script installs the project in `~/cube-alarm` for the user that runs it,
+so ensure you execute it as the user that should own the service.
 
 ### Bluetooth
 

--- a/setup_pi.sh
+++ b/setup_pi.sh
@@ -77,11 +77,11 @@ else
     print_status "Run 'sudo raspi-config' and go to Advanced Options > Audio"
 fi
 
-# Create project directory
-PROJECT_DIR="/home/pi/cube-alarm"
+# Create project directory inside the current user's home
+PROJECT_DIR="$HOME/cube-alarm"
 if [ ! -d "$PROJECT_DIR" ]; then
     print_status "Cloning project repository..."
-    cd /home/pi
+    cd "$HOME"
     git clone https://github.com/pshapiro/cube-alarm.git
     cd cube-alarm
     print_success "Project cloned"
@@ -121,7 +121,7 @@ if [ ! -f .env ]; then
 # Raspberry Pi Environment Configuration
 CUBE_MAC=CF:AA:79:C9:96:9C
 FLASK_ENV=production
-ALARM_SOUND_FILE=/home/pi/cube-alarm/sounds/alarm.wav
+ALARM_SOUND_FILE=$PROJECT_DIR/sounds/alarm.wav
 PI_DEPLOYMENT=true
 EOF
     print_success "Environment file created"


### PR DESCRIPTION
## Summary
- allow setup script to use any user home directory
- document default install location in README

## Testing
- `python3 -m py_compile backend/*.py test_pi_audio.py`
- `python3 test_pi_audio.py` *(fails: 'PiAudioManager' object has no attribute 'start_alarm_sound')*

------
https://chatgpt.com/codex/tasks/task_e_688ab04d8ec883258818a1a33c0ac465