### PR TITLE
Fix alarm sound path detection

### DIFF
--- a/backend/pi_audio.py
+++ b/backend/pi_audio.py
@@ -98,8 +98,12 @@ class PiAudioManager:
         if sound_file:
             sound_path = sound_file
         else:
-            base_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-            sound_path = os.path.join(base_dir, 'sounds', 'alarm.wav')
+            env_path = os.environ.get('ALARM_SOUND_FILE')
+            if env_path:
+                sound_path = env_path
+            else:
+                base_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+                sound_path = os.path.join(base_dir, 'sounds', 'alarm.wav')
         logger.info(f"🔊 Starting alarm sound for ID: {alarm_id} with file: {sound_path}")
         logger.info(f"🔊 DEBUG: Sound file exists: {os.path.exists(sound_path)}")
         logger.info(f"🔊 DEBUG: Current working directory: {os.getcwd()}")
@@ -423,8 +427,12 @@ class PiAudioManager:
     def test_audio(self) -> bool:
         """Test audio output."""
         logger.info(f"🔊 Testing audio output using method: {self.audio_method}")
-        base_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        sound_file = os.path.join(base_dir, 'sounds', 'alarm.wav')
+        env_path = os.environ.get('ALARM_SOUND_FILE')
+        if env_path:
+            sound_file = env_path
+        else:
+            base_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+            sound_file = os.path.join(base_dir, 'sounds', 'alarm.wav')
         return self._play_alarm_sound_once(sound_file)
 
 # Global audio manager instance


### PR DESCRIPTION
## Summary
- allow overriding Pi alarm sound path via `ALARM_SOUND_FILE` env var

## Testing
- `python -m py_compile backend/alarm_server.py backend/ble_worker.py backend/cube_worker.py backend/enhanced_gan_cube.py backend/gan_alarm_integration.py backend/gan_decrypt.py backend/gan_protocol_driver.py backend/pi_audio.py`
- `python test_pi_audio.py` *(fails: `No audio method available`)*

------
https://chatgpt.com/codex/tasks/task_e_688cf43ea6988325bed9d8c2d24e7577