### PR TITLE
Fix audio fallback when no sound method

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,15 @@ This project turns a GAN Bluetooth cube into an alarm clock. When the alarm ring
    ```
 2. Run the server
    ```bash
-   python backend/alarm_server.py
-   ```
+  python backend/alarm_server.py
+  ```
+
+### Custom alarm sound
+
+The audio manager loads the alarm sound from the path stored in the
+`ALARM_SOUND_FILE` environment variable.  If this variable is not set, it
+defaults to `sounds/alarm.wav` relative to the project root.  Adjust this
+variable to use a custom sound file.
 
 ## Frontend (React)
 

--- a/backend/pi_audio.py
+++ b/backend/pi_audio.py
@@ -98,8 +98,12 @@ class PiAudioManager:
         if sound_file:
             sound_path = sound_file
         else:
-            base_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-            sound_path = os.path.join(base_dir, 'sounds', 'alarm.wav')
+            env_path = os.environ.get('ALARM_SOUND_FILE')
+            if env_path:
+                sound_path = env_path
+            else:
+                base_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+                sound_path = os.path.join(base_dir, 'sounds', 'alarm.wav')
         logger.info(f"🔊 Starting alarm sound for ID: {alarm_id} with file: {sound_path}")
         logger.info(f"🔊 DEBUG: Sound file exists: {os.path.exists(sound_path)}")
         logger.info(f"🔊 DEBUG: Current working directory: {os.getcwd()}")
@@ -229,7 +233,7 @@ class PiAudioManager:
                 return self._play_speaker_test(sound_file, alarm_id)
             else:
                 logger.error("❌ No audio method available")
-                return False
+                return self._play_console_beep()
         
         except Exception as e:
             logger.error(f"❌ Error playing alarm sound: {e}")
@@ -419,12 +423,26 @@ class PiAudioManager:
         except Exception as e:
             logger.error(f"❌ speaker-test failed: {e}")
             return False
+
+    def _play_console_beep(self) -> bool:
+        """Fallback beep using the console bell character."""
+        try:
+            print("\a", end="", flush=True)
+            time.sleep(0.2)
+            return True
+        except Exception as e:
+            logger.error(f"❌ Console beep failed: {e}")
+            return False
     
     def test_audio(self) -> bool:
         """Test audio output."""
         logger.info(f"🔊 Testing audio output using method: {self.audio_method}")
-        base_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        sound_file = os.path.join(base_dir, 'sounds', 'alarm.wav')
+        env_path = os.environ.get('ALARM_SOUND_FILE')
+        if env_path:
+            sound_file = env_path
+        else:
+            base_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+            sound_file = os.path.join(base_dir, 'sounds', 'alarm.wav')
         return self._play_alarm_sound_once(sound_file)
 
 # Global audio manager instance

--- a/test_pi_audio.py
+++ b/test_pi_audio.py
@@ -10,6 +10,11 @@ import sys
 import os
 import time
 
+# Ensure alarm sound path matches PiAudioManager logic
+if not os.environ.get("ALARM_SOUND_FILE"):
+    base_dir = os.path.dirname(os.path.abspath(__file__))
+    os.environ["ALARM_SOUND_FILE"] = os.path.join(base_dir, "sounds", "alarm.wav")
+
 # Add backend directory to path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'backend'))
 


### PR DESCRIPTION
## Summary
- document `ALARM_SOUND_FILE` in README
- fallback to console beep when no audio method is available
- ensure `test_pi_audio.py` sets a default alarm sound file

## Testing
- `python -m py_compile backend/alarm_server.py backend/ble_worker.py backend/cube_worker.py backend/enhanced_gan_cube.py backend/gan_alarm_integration.py backend/gan_decrypt.py backend/gan_protocol_driver.py backend/pi_audio.py`
- `python test_pi_audio.py`

------
https://chatgpt.com/codex/tasks/task_e_688cf43ea6988325bed9d8c2d24e7577