### PR TITLE
Fix PATH in service file

### DIFF
--- a/setup_pi.sh
+++ b/setup_pi.sh
@@ -160,7 +160,9 @@ Type=simple
 User=${CURRENT_USER}
 Group=${CURRENT_USER}
 WorkingDirectory=$PROJECT_DIR
-Environment=PATH=$PROJECT_DIR/venv/bin
+# Ensure system binaries like aplay are accessible
+Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$PROJECT_DIR/venv/bin
+EnvironmentFile=$PROJECT_DIR/.env
 ExecStart=$PROJECT_DIR/venv/bin/python backend/alarm_server.py
 Restart=always
 RestartSec=10


### PR DESCRIPTION
## Summary
- fix PATH so system utilities like `aplay` are found when running as a service
- load environment variables from `.env` inside the service

## Testing
- `python test_pi_audio.py`

------
https://chatgpt.com/codex/tasks/task_e_688d126ee80483259672a6750c363652