### PR TITLE
Handle aplay startup race so alarm audio reliably plays

### DIFF
--- a/backend/pi_audio.py
+++ b/backend/pi_audio.py
@@ -314,12 +314,15 @@ class PiAudioManager:
                 process = subprocess.Popen(['sh', '-c', f'while true; do aplay -D plughw:0,0 "{sound_file}"; done'],
                                          stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                                          preexec_fn=os.setsid, env=clean_env)  # Create new process group with clean env
-                
+
                 # Store process reference if alarm_id provided (for termination)
                 if alarm_id:
                     self.active_processes[alarm_id] = process
                     logger.info(f"🔊 DEBUG: Stored process {process.pid} for alarm {alarm_id}")
-                
+
+                # Give process a moment to fail fast if there's an audio error
+                time.sleep(0.1)
+
                 # Check if process is still running (don't wait for completion)
                 if process.poll() is None:
                     # Process is still running, which is good for continuous playback


### PR DESCRIPTION
## Summary
- give `aplay` a brief moment to fail before checking its status
- return an error if `aplay` exits immediately so alarms don't silently start without sound

## Testing
- `python test_pi_audio.py > /tmp/test.log`
- `tail -n 20 /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_688d709fee708325b0cf16b2fb5f3961