### PR TITLE
Fix missing alarm sound after power cycle

### DIFF
--- a/backend/pi_audio.py
+++ b/backend/pi_audio.py
@@ -137,6 +137,14 @@ class PiAudioManager:
         logger.info(f"🔊 DEBUG: Sound file exists: {os.path.exists(sound_path)}")
         logger.info(f"🔊 DEBUG: Current working directory: {os.getcwd()}")
         logger.info(f"🔊 DEBUG: Environment variables: PULSE_RUNTIME_PATH={os.environ.get('PULSE_RUNTIME_PATH')}, XDG_RUNTIME_DIR={os.environ.get('XDG_RUNTIME_DIR')}")
+
+        # Re-detect ALSA device on each playback in case the system booted
+        # before audio devices were fully initialized (common after power
+        # cycles).  This ensures we always target the actual analog output
+        # rather than falling back to the HDMI default.
+        self.alsa_card, self.alsa_device = self._detect_alsa_device()
+        self.alsa_output = f"plughw:{self.alsa_card},{self.alsa_device}"
+        logger.info(f"🔊 DEBUG: Using ALSA output {self.alsa_output}")
         
         # Create stop event for this alarm
         stop_event = threading.Event()


### PR DESCRIPTION
## Summary
- Refresh ALSA device detection each time an alarm sound plays
- Forces audio to use the active analog output so alarms ring after reboots

## Testing
- `python test_pi_audio.py >/tmp/test.log && tail -n 20 /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_6899616e457c8325b8177bc0e1d17959